### PR TITLE
(#39) Fix member images

### DIFF
--- a/src/components/SingleStaffListEntry.js
+++ b/src/components/SingleStaffListEntry.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "gatsby";
+import Image from '../components/Image';
 import "../scss/components/_staff.scss";
 
 class SingleStaffListEntry extends React.Component {
@@ -26,7 +27,7 @@ class SingleStaffListEntry extends React.Component {
 								<div className={"member-image"}>
 										<Link to={this.displayUrl}
 										className={this.linkClass}>
-												<img
+												<Image
 														src={this.props.source}
 														alt={this.props.alt}
 												/>

--- a/src/components/SingleStaffMember.js
+++ b/src/components/SingleStaffMember.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "gatsby";
+import Image from '../components/Image';
 import "../scss/components/_single-staff-member.scss";
 
 class SingleStaffMember extends React.Component {
@@ -7,8 +7,7 @@ class SingleStaffMember extends React.Component {
 				return (
 						<div className={"single-member"}>
 								<div className={"member-image"}>
-										<img
-												typeof="foaf:Image"
+										<Image
 												src={this.props.source}
 												alt={this.props.name}
 										/>

--- a/src/content/pages/about-staff.md
+++ b/src/content/pages/about-staff.md
@@ -11,15 +11,15 @@ Staff members of the President's Cancer Panel coordinate the work that advances 
 
 <ul class="staff-list">
 <single-staff-list-entry
-		source="../../images/Maureen-Johnson-768x768.jpg"
+		source="Maureen-Johnson-768x768.jpg"
 		alt="Maureen R. Johnson, Ph.D."
 		title="Executive Secretary"></single-staff-list-entry>
 <single-staff-list-entry
-		source="../../images/samantha-resized.jpg"
+		source="samantha-resized_1.jpg"
 		alt="Samantha L. Finstad, Ph.D."
 		title="Senior Health Science Policy Advisor"></single-staff-list-entry>
 <single-staff-list-entry
-		source="../../images/daniela-resized.jpg"
+		source="daniela-resized_1.jpg"
 		alt="Daniela Monterroza"
 		title="Health Communications Fellow"></single-staff-list-entry>
 </ul>

--- a/src/content/pages/members-berger.md
+++ b/src/content/pages/members-berger.md
@@ -3,7 +3,7 @@ title: Dr. Mitchel S. Berger, Staff Member
 slug: /members/berger
 ---
 <single-staff-member
-	source="../images/bergerm_headshot-squarecrop_2_0.png"
+	source="bergerm_headshot-squarecrop_2_0.png"
 	name="Dr. Mitchel S. Berger">
 </single-staff-member>
 

--- a/src/content/pages/members-brown.md
+++ b/src/content/pages/members-brown.md
@@ -3,7 +3,7 @@ title: Dr. Carol L. Brown, Staff Member
 slug: /members/brown
 ---
 <single-staff-member
-	source="../images/dr._brown-squarecrop.png"
+	source="dr._brown-squarecrop.png"
 	name="Dr. Carol L. Brown">
 </single-staff-member>
 

--- a/src/content/pages/members-jaffee.md
+++ b/src/content/pages/members-jaffee.md
@@ -3,7 +3,7 @@ title: Dr. Elizabeth M. Jaffee, PCP Chair
 slug: /members/jaffee
 ---
 <single-staff-member
-	source="../images/dr._elizabeth_jaffee_headshot-squarecrop.jpg"
+	source="dr._elizabeth_jaffee_headshot-squarecrop.jpg"
 	name="Dr. Elizabeth M. Jaffee">
 </single-staff-member>
 

--- a/src/content/pages/members.md
+++ b/src/content/pages/members.md
@@ -6,19 +6,19 @@ Panel members are distinguished members of the scientific, research, and public 
 
 <ul class="staff-list">
 <single-staff-list-entry
-		source="../../images/dr._elizabeth_jaffee_headshot-squarecrop.jpg"
+		source="dr._elizabeth_jaffee_headshot-squarecrop.jpg"
 		alt="Dr. Elizabeth M. Jaffee"
 		title="PCP Chair"
 		url="/members/jaffee">
 </single-staff-list-entry>
 <single-staff-list-entry
-		source="../../images/bergerm_headshot-squarecrop_2_0.png"
+		source="bergerm_headshot-squarecrop_2_0.png"
 		alt="Dr. Mitchel S. Berger"
 		title="PCP Member"
 		url="/members/berger">
 </single-staff-list-entry>
 <single-staff-list-entry
-		source="../../images/dr._brown-squarecrop.png"
+		source="dr._brown-squarecrop.png"
 		alt="Dr. Carol L. Brown"
 		title="PCP Member"
 		url="/members/brown">

--- a/src/scss/components/_single-staff-member.scss
+++ b/src/scss/components/_single-staff-member.scss
@@ -9,6 +9,7 @@
 		@include at-media(tablet) {
 			max-width: 40%;
 		}
+		width: 100%;
 		img {
 			border-radius: 50%;
 		}


### PR DESCRIPTION
Migrates member images to use the `Image` element and thus by Gatsby native.

At some point we should change from gatsby-image to gatsby-plugin-image, but it'll work for now.

Closes #39.