### PR TITLE
(#98) Spikes breadcrumbs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,81 +8,81 @@ module.exports = {
 		description: `The President's Cancer Panel monitors the activities of the National Cancer Program and reports to the President of the United States on barriers to progress in reducing the burden of cancer.`,
 		siteUrl: `https://prescancerpanel.cancer.gov`,
 		footerLinks: [
-				{
-						name: 'PresCancerPanel@mail.nih.gov',
-						link: 'mailto:PresCancerPanel@mail.nih.gov'
-				},
-				{
-						name: 'HHS Vulnerability Disclosure',
-						link: 'https://www.hhs.gov/vulnerability-disclosure-policy/index.html'
-				}
+			{
+				name: 'PresCancerPanel@mail.nih.gov',
+				link: 'mailto:PresCancerPanel@mail.nih.gov'
+			},
+			{
+				name: 'HHS Vulnerability Disclosure',
+				link: 'https://www.hhs.gov/vulnerability-disclosure-policy/index.html'
+			}
 		],
 		iconLinks: [
 			{
-					name: 'Twitter',
-					link: 'https://twitter.com/prescancerpanel',
-					height: 48,
-					width: 48
+				name: 'Twitter',
+				link: 'https://twitter.com/prescancerpanel',
+				height: 48,
+				width: 48
 			},
 			{
-					name: 'Linkedin',
-					link: 'https://www.linkedin.com/company/president\'s-cancer-panel/',
-					height: 48,
-					width: 48
+				name: 'Linkedin',
+				link: 'https://www.linkedin.com/company/president\'s-cancer-panel/',
+				height: 48,
+				width: 48
 			},
 			{
-					name: 'email',
-					link: 'mailto:PresCancerPanel@mail.nih.gov',
-					height: 48,
-					width: 48
+				name: 'email',
+				link: 'mailto:PresCancerPanel@mail.nih.gov',
+				height: 48,
+				width: 48
 			}
 		],
-		menuLinks:[
+		menuLinks: [
 			{
 				name: 'Home',
 				link: '/'
 			},
 			{
-					name: 'Members',
-					link: '/members/'
+				name: 'Members',
+				link: '/members/'
 			},
 			{
-					name: 'About',
-					link: '/about/',
-					sublinks: [
+				name: 'About',
+				link: '/about/',
+				sublinks: [
+					{
+						name: 'History',
+						link: '/about/history'
+					},
+					{
+						name: 'Process',
+						link: '/about/process'
+					},
+					{
+						name: 'Staff',
+						link: '/about/staff'
+					},
+					{
+						name: 'Blogs',
+						link: '/about/blogs',
+						sublinks: [
 							{
-									name: 'History',
-									link: '/about/history'
-							},
-							{
-									name: 'Process',
-									link: '/about/process'
-							},
-							{
-									name: 'Staff',
-									link: '/about/staff'
-							},
-							{
-									name: 'Blogs',
-									link: '/about/blogs',
-									sublinks: [
-											{
-													name: '50th Anniversary',
-													link: '/about/nca50/'
-											}
-									],
-							},
-					]
+								name: '50th Anniversary',
+								link: '/about/nca50/'
+							}
+						],
+					},
+				]
 			},
 			{
-					name: 'Reports & Meetings',
-					link: '/reports/'
+				name: 'Reports & Meetings',
+				link: '/reports/'
 			},
 		]
 	},
 	pathPrefix: process.env.PREFIX_PATH
-		  ? process.env.PREFIX_PATH
-		  : undefined,
+		? process.env.PREFIX_PATH
+		: undefined,
 	plugins: [
 		{
 			resolve: `gatsby-plugin-sass`,
@@ -98,9 +98,31 @@ module.exports = {
 		'gatsby-plugin-netlify-cms',
 		'gatsby-plugin-sitemap',
 		'gatsby-remark-component',
-		'gatsby-plugin-image',
-		'gatsby-plugin-sharp',
-		'gatsby-transformer-sharp',
+		{
+			resolve: `gatsby-plugin-breadcrumb`,
+			options: {
+				// useAutoGen: required 'true' to use autogen
+				useAutoGen: true,
+				// exclude: optional, include this array to exclude paths you don't want to
+				// generate breadcrumbs for (see below for details).
+				exclude: [
+					`**/dev-404-page/**`,
+					`**/404/**`,
+					`**/404.html`,
+					`**/offline-plugin-app-shell-fallback/**`
+				],
+				// trailingSlashes: optional, will add trailing slashes to the end
+				// of crumb pathnames. default is false
+				trailingSlashes: true,
+				// usePathPrefix: optional, if you are using pathPrefix above
+				usePathPrefix: process.env.PREFIX_PATH
+					? process.env.PREFIX_PATH
+					: undefined,
+			}
+		},
+			'gatsby-plugin-image',
+			'gatsby-plugin-sharp',
+			'gatsby-transformer-sharp',
 		{
 			resolve: 'gatsby-source-filesystem',
 			options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "backstopjs": "^6.2.1",
         "gatsby": "^5.8.1",
         "gatsby-image": "^3.11.0",
+        "gatsby-plugin-breadcrumb": "^12.3.2",
         "gatsby-plugin-image": "^3.7.0",
         "gatsby-plugin-netlify-cms": "^7.5.0",
         "gatsby-plugin-node-reload": "^1.1.0",
@@ -11242,6 +11243,19 @@
         "@parcel/core": "^2.0.0"
       }
     },
+    "node_modules/gatsby-plugin-breadcrumb": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-breadcrumb/-/gatsby-plugin-breadcrumb-12.3.2.tgz",
+      "integrity": "sha512-MOIziBA+sAQPNJMC5aRsHO+734CPxaPhOqMUAXBN7v6lKv4kp99QXHb5RCocN5X4sSDZrFWDOJc3oTFqEqfDEQ==",
+      "dependencies": {
+        "identity-obj-proxy": "3.0.0",
+        "prop-types": "15.8.1",
+        "wildcard-match": "5.1.2"
+      },
+      "peerDependencies": {
+        "gatsby": "3.x - 5.x"
+      }
+    },
     "node_modules/gatsby-plugin-image": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.8.0.tgz",
@@ -12745,6 +12759,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -13518,6 +13537,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ieee754": {
@@ -25904,6 +25934,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
+    },
+    "node_modules/wildcard-match": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.2.tgz",
+      "integrity": "sha512-qNXwI591Z88c8bWxp+yjV60Ch4F8Riawe3iGxbzquhy8Xs9m+0+SLFBGb/0yCTIDElawtaImC37fYZ+dr32KqQ=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "backstopjs": "^6.2.1",
     "gatsby": "^5.8.1",
     "gatsby-image": "^3.11.0",
+    "gatsby-plugin-breadcrumb": "^12.3.2",
     "gatsby-plugin-image": "^3.7.0",
     "gatsby-plugin-netlify-cms": "^7.5.0",
     "gatsby-plugin-node-reload": "^1.1.0",

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { Link } from "gatsby";
+
+export default function Breadcrumbs ({ crumbs }) {
+  console.log(crumbs);
+  const links = crumbs.map((crumb, index) => (
+    <React.Fragment key={index}>
+      <Link to={crumb.pathname}>{crumb.crumbLabel}</Link>
+      {index !== crumbs.length - 1 && " - "}
+    </React.Fragment>
+  ));
+
+  return <>{links}</>;
+}

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -3,8 +3,12 @@ import { Script } from "gatsby";
 import Header from "./Header";
 import { Footer } from "./Footer";
 import '../scss/styles.scss';
+import Breadcrumbs from "./Breadcrumbs"
 
-export default function Layout({ children }) {
+export default function Layout({ children, pageContext }) {
+	const {
+		breadcrumb: { crumbs },
+	  } = pageContext
 	return (
 		<div role={"document"} className={"pcp-document-container"}>
 			<Header />
@@ -13,6 +17,7 @@ export default function Layout({ children }) {
 					<div className={"grid-row"}>
 						<div className={"grid-col-12"}>
 							<div className={"pcp-sections"}>
+			<Breadcrumbs crumbs={crumbs} />
 								<div className="post-body">
 									{children}
 								</div>

--- a/src/pages/about/blogs.js
+++ b/src/pages/about/blogs.js
@@ -6,7 +6,7 @@ import Layout from "../../components/Layout"
 import { SEO } from "../../components/Seo"
 import { LeftTopNavigation } from "../../components/LeftTopNavigation"
 
-export default function BlogPage({ data: { allMarkdownRemark } }) {
+export default function BlogPage({ data: { allMarkdownRemark }, pageContext }) {
   const path = { relativeDirectory: "about" }
   const { edges } = allMarkdownRemark
 
@@ -17,7 +17,7 @@ export default function BlogPage({ data: { allMarkdownRemark } }) {
     blogLinks.push(<p><Link to={"/" + post.parent.relativeDirectory + "/" + post.parent.name} >{post.frontmatter.title}</Link ></p>)
   }
   return (
-    <Layout>
+    <Layout pageContext={pageContext}>
       <div className="post-body">
         <div className="full-report-container">
           <div className="left-nav-container">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,9 +5,9 @@ import IntroText from "../components/IntroText"
 import SingleHomepageBox from "../components/SingleHomepageBox"
 import { SEO } from "../components/Seo"
 
-const IndexPage = () => {
+const IndexPage = ({pageContext}) => {
   return (
-    <Layout>
+    <Layout pageContext={pageContext}>
       <div>
         <p>
           <HeroImage

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -4,9 +4,9 @@ import { Script, withPrefix } from "gatsby"
 import '../scss/search.scss'
 import { SEO } from "../components/Seo"
 
-const SearchPage = () => {
+const SearchPage = ({pageContext}) => {
 	return (
-	  <Layout>
+	  <Layout pageContext={pageContext}>
 		<div id="NCI-sws-app-root"></div>
 		<Script id="NCI-sws-app-root-js-config" type="text/javascript">{(function() {
 

--- a/src/pages/{MarkdownRemark.parent__(File)__relativeDirectory}/{MarkdownRemark.parent__(File)__name}.js
+++ b/src/pages/{MarkdownRemark.parent__(File)__relativeDirectory}/{MarkdownRemark.parent__(File)__name}.js
@@ -6,13 +6,13 @@ import LeftNavTemplate from "../../templates/LeftNav";
 import LeftNavsSubSectionsTemplate from "../../templates/LeftNavSubSections";
 import BlogTemplate from "../../templates/Blog";
 
-export default function GeneratedPage({ data: { markdownRemark } }) {
+export default function GeneratedPage({ data: { markdownRemark }, pageContext }) {
 	const { frontmatter, htmlAst, parent } = markdownRemark;
 	const templates = {
-		blog: <BlogTemplate frontmatter={frontmatter} htmlAst={htmlAst} path={parent} />,
-		left_nav: <LeftNavTemplate frontmatter={frontmatter} htmlAst={htmlAst} path={parent} />,
-		left_nav_sub_sections: <LeftNavsSubSectionsTemplate frontmatter={frontmatter} htmlAst={htmlAst} path={parent} />,
-		single_page: <SinglePageTemplate frontmatter={frontmatter} htmlAst={htmlAst} />,
+		blog: <BlogTemplate frontmatter={frontmatter} htmlAst={htmlAst} path={parent} pageContext={pageContext} />,
+		left_nav: <LeftNavTemplate frontmatter={frontmatter} htmlAst={htmlAst} path={parent} pageContext={pageContext} />,
+		left_nav_sub_sections: <LeftNavsSubSectionsTemplate frontmatter={frontmatter} htmlAst={htmlAst} path={parent} pageContext={pageContext} />,
+		single_page: <SinglePageTemplate frontmatter={frontmatter} htmlAst={htmlAst} pageContext={pageContext} />,
 	};
 
 	return templates[frontmatter.template];

--- a/src/templates/Blog.js
+++ b/src/templates/Blog.js
@@ -3,9 +3,9 @@ import Layout from "../components/Layout";
 import { LeftTopNavigation } from "../components/LeftTopNavigation";
 import MainText from "../components/MainText";
 
-export default function BlogTemplate({ frontmatter, htmlAst, path }) {
+export default function BlogTemplate({ frontmatter, htmlAst, path, pageContext }) {
 	return (
-		<Layout>
+		<Layout pageContext={pageContext}>
 			<div className="full-report-container">
 				<div className="left-nav-container">
 					<LeftTopNavigation root={path}></LeftTopNavigation>

--- a/src/templates/LeftNav.js
+++ b/src/templates/LeftNav.js
@@ -3,9 +3,9 @@ import Layout from "../components/Layout";
 import { LeftTopNavigation } from "../components/LeftTopNavigation";
 import MainText from "../components/MainText";
 
-export default function LeftNavTemplate({ frontmatter, htmlAst, path }) {
+export default function LeftNavTemplate({ frontmatter, htmlAst, path, pageContext }) {
 	return (
-		<Layout>
+		<Layout pageContext={pageContext}>
 			<div className="full-report-container">
 				<div className="left-nav-container">
 					<LeftTopNavigation root={path}></LeftTopNavigation>

--- a/src/templates/LeftNavSubSections.js
+++ b/src/templates/LeftNavSubSections.js
@@ -3,9 +3,9 @@ import Layout from "../components/Layout";
 import { LeftNavigation } from "../components/LeftNavigation";
 import MainText from "../components/MainText";
 
-export default function LeftNavsSubSectionsTemplate({ frontmatter, htmlAst, path }) {
+export default function LeftNavsSubSectionsTemplate({ frontmatter, htmlAst, path, pageContext }) {
 	return (
-		<Layout>
+		<Layout pageContext={pageContext}>
 			<h2 className={"post-title"}>{frontmatter.sectionTitle}</h2>
 			<div className="full-report-container">
 				<div className="left-nav-container">

--- a/src/templates/SinglePage.js
+++ b/src/templates/SinglePage.js
@@ -2,9 +2,9 @@ import * as React from "react";
 import Layout from "../components/Layout";
 import MainText from "../components/MainText";
 
-export default function SinglePageTemplate({ frontmatter, htmlAst }) {
+export default function SinglePageTemplate({ frontmatter, htmlAst, pageContext }) {
 	return (
-		<Layout>
+		<Layout pageContext={pageContext}>
 			<h2 className={"post-title"}>{frontmatter.title}</h2>
 			<div className="post-body">
 				<MainText html={htmlAst}></MainText>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6814,6 +6814,15 @@ gatsby-parcel-config@1.8.0:
     "@parcel/transformer-js" "2.8.3"
     "@parcel/transformer-json" "2.8.3"
 
+gatsby-plugin-breadcrumb@^12.3.2:
+  version "12.3.2"
+  resolved "https://registry.npmjs.org/gatsby-plugin-breadcrumb/-/gatsby-plugin-breadcrumb-12.3.2.tgz"
+  integrity sha512-MOIziBA+sAQPNJMC5aRsHO+734CPxaPhOqMUAXBN7v6lKv4kp99QXHb5RCocN5X4sSDZrFWDOJc3oTFqEqfDEQ==
+  dependencies:
+    identity-obj-proxy "3.0.0"
+    prop-types "15.8.1"
+    wildcard-match "5.1.2"
+
 gatsby-plugin-image@^3.7.0:
   version "3.8.0"
   resolved "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.8.0.tgz"
@@ -7727,6 +7736,11 @@ gzip-size@^6.0.0:
   dependencies:
     duplexer "^0.1.2"
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz"
@@ -8166,6 +8180,13 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
+
+identity-obj-proxy@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz"
+  integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.12, ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
@@ -11867,7 +11888,7 @@ prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1, prop-types@15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -15599,6 +15620,11 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+wildcard-match@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.2.tgz"
+  integrity sha512-qNXwI591Z88c8bWxp+yjV60Ch4F8Riawe3iGxbzquhy8Xs9m+0+SLFBGb/0yCTIDElawtaImC37fYZ+dr32KqQ==
 
 wildcard@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This spikes gatsby-plugin-sitemap.

I don't _think_ we can use the "Click Tracking" version of the plugin, though I'm not positive. Since we're hosting a fully static site I don't believe it would be available.

I tried to get the "Auto Gen" capability to work. The plugin's `<Breadcrumbs>` component was throwing errors for me. But I was able to use the plugin to add to the `pageContext` and then pass that into a custom `Breadcrumbs` component I created myself.

That _does_ work, but there is a major problem: The system appears to be generating the breadcrumbs from the `path/to/the/page/in/the/url` and that has some side effects:

1. It doesn't go to the Gatsby pages API and get the title, so the titles are all ugly lowercase versions of the path segments. There is an override option by path name in the setup, but that would be very unwieldy.
2. Not every path segment has an index page at the moment (e.g. in `/reports/2016/report-name` the `2016` folder does not have an index page). We would have to go add index pages for each one.

The additional work required to do the styling would be minimal, so it's really just how we would handle the problem above. The only easy route would be to:

- Apply standard title casing automatically to each link using CSS
- Add `index.md` pages for every folder, even if they just pointed back to their parents

I am not at all confident that the results would be good enough to use, though.