### PR TITLE
(#121) Update search bar IDs for analytics

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -6,12 +6,12 @@ export const SearchBar = () => {
 	return (
 		<>
 			<div className={'nci-header-nav__secondary'}>
-				<form className={'nci-header-search'} method={'get'} action={withPrefix('/search')} role={'search'}>
+				<form className={'nci-header-search'} method={'get'} action={withPrefix('/search')} role={'search'} id={'search'}>
 					<label className={'usa-sr-only'} htmlFor={'nci-header-search__field'}>
 						Search
 					</label>
 
-					<input className={'usa-input'} id={'nci-header-search__field'} type={'search'} name={'swKeyword'} data-autosuggest-collection={'cgov'} />
+					<input className={'usa-input'} id={'searchbox-header-input'} type={'search'} name={'swKeyword'} data-autosuggest-collection={'cgov'} />
 					<button className={'usa-button nci-header-search__search-button'} type={'submit'} aria-label={'Search'}>
 						<svg xmlns={'http://www.w3.org/2000/svg'} width={'15'} height={'15'} viewBox={'0 0 512 512'}>
 							<path d={'M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z'} />


### PR DESCRIPTION
These specific IDs are needed to support tracking searches from the header.

Closes #121